### PR TITLE
Fix scripts to work with gitfiles (pseudo-symlinks)

### DIFF
--- a/git-attach-head
+++ b/git-attach-head
@@ -27,7 +27,7 @@ fi
 ## TODO: do some error checking?
 
 ## stop if HEAD is a ref already
-if [[ $(cat .git/HEAD | cut -c1-4) == "ref:" ]]; then
+if git symbolic-ref HEAD 2> /dev/null ; then
     exit 0
 fi
 

--- a/git-ccommit
+++ b/git-ccommit
@@ -53,7 +53,7 @@ fi
 if [[ "$@" == *--allow-empty* ]] || ([ $a -eq 1 ] && ! git check-clean --unstaged --unmerged --exit-code --ignore-submodules=dirty) || ! git check-clean --uncommitted --exit-code --ignore-submodules=dirty; 
 then
     ## check for detached head
-    if [[ $(cat .git/HEAD | cut -c1-4) != "ref:" ]]; then
+    if ! git symbolic-ref HEAD 2> /dev/null ; then
 	echo "Error in $PWD:"
 	echo " Refused to commit in detached head state. Use \"git rcheckout <branchname>\" to attach HEAD. List branches with \"git branch -v\"."
 	exit 1

--- a/git-check-branch
+++ b/git-check-branch
@@ -17,7 +17,7 @@ EOF
     exit 0;
 fi
 
-if [[ $(cat .git/HEAD | cut -c1-4) != "ref:" ]]; then
+if ! git symbolic-ref HEAD 2> /dev/null ; then
     ## detached head cannot be remote tracking branch...
     ## ...but: if there are no new commits, we can safely ignore this
     ## FIXME: this test only succeed if the new commit is actually


### PR DESCRIPTION
In git v1.5.4, gitfiles were born.  These files are like symlinks
but are cross-platform.  They're _not_ symlinks, and so they do
not actually link transparently to some remote directory.  Instead
they are text files containing information about a remote directory.
They allow a .git directory to exist elsewhere rather than actually
in the workdir's ".git/" space.

Since git v1.7.8 gitfiles are used for all submodules. Therefore
things like "cat .git/HEAD" no longer work in submodules.

You can find the real gitdir like this:
`gitdir=$(git rev-parse --git-dir)`

But it looks like all three locations that are doing "cat .git/HEAD"
are really checking to see if HEAD is detatched.  This can be tested
using this command instead:
`git symbolic-ref HEAD`

If we're on a detached head, this command returns an error.

So, update the scripts to test for detached head using a standard
git-icism instead of relying on foreknowledge of the .git directory
internals.
