### PR TITLE
Stage .gitmodules changes, else you get an error

### DIFF
--- a/git-rm-submodule
+++ b/git-rm-submodule
@@ -66,6 +66,7 @@ cd "$cdup"
 url=`(git config --get submodule."$dir".url) || echo "unknown"`
 ## remove config entries
 (git config -f .gitmodules --remove-section submodule."$dir" 2>/dev/null) || echo -n ""
+(git add .gitmodules 2>/dev/null) || echo -n ""
 (git config --remove-section submodule."$dir" 2>/dev/null) || echo -n ""
 git rm --cached "$dir"
 rm -rf "$dir"


### PR DESCRIPTION
If you do not stage your changes to .gitmodules, before `git rm --cached`, you
get the following error:

```
fatal: Please, stage your changes to .gitmodules or stash them to proceed
```
